### PR TITLE
fix(docs): ruby comments use # not //

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,14 @@ This SDK contains the ATS, HRIS, CRM, Ticketing, Accounting, and File Storage ca
 Each category is namespaced:
 
 ```ruby
-
 merge = Merge::Client.new(
   api_key: 'YOUR_API_KEY',
   account_token: 'YOUR_ACCOUNT_TOKEN'
 )
 
-merge.ats. // APIs specific to the ATS Category
+merge.ats. # APIs specific to the ATS Category
 
-merge.hris. // APIs specific to the HRIS Category
+merge.hris. # APIs specific to the HRIS Category
 ```
 
 ## Usage


### PR DESCRIPTION
Hello Merge friends! Congrats on getting this out there, it looks like a great SDK at first blush.

Just a small nit that some comments in the README are using the wrong syntax. I do it all the time :)

Note: I am aware the repo is generated and my change may not be merged as-is, but figured a PR would still be more helpful than raising an issue.