### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,4 +1,5 @@
 # Specify files that shouldn't be modified by Fern
+CODEOWNERS
 README.md
 test/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*                                          @merge-api/approved-sdk-reviewers


### PR DESCRIPTION
## Summary
- Adds a CODEOWNERS file assigning `@merge-api/approved-sdk-reviewers` as reviewers for all files
- Adds CODEOWNERS to .fernignore to prevent Fern from overwriting it

🤖 Generated with [Claude Code](https://claude.com/claude-code)